### PR TITLE
👨🏼‍🚀 Settings patch PR

### DIFF
--- a/Cards/CardManager.swift
+++ b/Cards/CardManager.swift
@@ -23,7 +23,6 @@ protocol CardService {
     
 }
 
-
 struct Card: Codable {
     let name: String
     let cardNumber: String
@@ -78,21 +77,13 @@ class CardManager: CardService {
         }
     }
     
-     func delete(_ card: Card, completion: () -> Void) {
-        
+    func delete(_ card: Card, completion: () -> Void) {
         while let index = cards.index(where: {$0.cardNumber == card.cardNumber}) {
-            
             cards.remove(at: index)
         }
-        
-        
-
-//        deleteCards {
-//            cards = c
-            saveCardsToKeychain(completion: {
-                completion()
-            })
-//        }
+        saveCardsToKeychain(completion: {
+            completion()
+        })
     }
     
     private func saveCardsToKeychain(completion: () -> Void) {

--- a/Cards/ViewControllers/CardViewController.swift
+++ b/Cards/ViewControllers/CardViewController.swift
@@ -81,27 +81,27 @@ class CardViewController: UIViewController {
     fileprivate func presentMoreOptions(index: Int, fromView: CardCell?) {
         
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let action = UIAlertAction(title: NSLocalizedString("Delete", comment: "removing file"), style: .destructive) { [weak self] _ in
+        let deleteAction = UIAlertAction(title: NSLocalizedString("Delete", comment: ""), style: .destructive) { [weak self] _ in
             if let card = self?.cardManager.cardAtIndex(index) {
                 self?.cardManager.delete(card, completion: {
                     self?.tableView.reloadData()
                 })
             }
         }
-        alert.addAction(action)
         
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel, handler: nil)
-        alert.addAction(cancelAction)
         
-        let copyAction = UIAlertAction(title: "Copy", style: .default) { (Action) in
-            let cardNumber = fromView?.numberLabel.text
+        let copyAction = UIAlertAction(title: NSLocalizedString("Copy number", comment: ""), style: .default) { (Action) in
+            if let cardNumber = fromView?.numberLabel.text {
+                let numberWithNoSpacing = cardNumber.components(separatedBy: .whitespaces).joined()
+                let pasteboard = UIPasteboard.general
+                pasteboard.string = numberWithNoSpacing
+            }
         }
-        let pasteboard = UIPasteboard.general
-        pasteboard.string = fromView?.numberLabel.text
-        
+
         alert.addAction(copyAction)
-        
-        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
         
         if let v = fromView {
             alert.popoverPresentationController?.sourceView = v

--- a/Cards/ViewControllers/CardViewController.swift
+++ b/Cards/ViewControllers/CardViewController.swift
@@ -110,7 +110,6 @@ class CardViewController: UIViewController {
         
         present(alert, animated: true, completion: nil)
     }
-
 }
 
 extension CardViewController: UITableViewDelegate, UITableViewDataSource {


### PR DESCRIPTION
# What changed 🤷🏼‍♂️ 

- Removed unwanted code from `CardManager`
- Renamed `action` -> `deleteAction` to make it more obvious 
- Moved the `UIPasteboard` code into the `copyAction` block
- Rearaged the actions 👉🏼 [copy, delete, cancel]

# Lets chat Code 👨🏼‍🚀

### The copied number should have no spacing 
> (i.e 1234 5678 9123 4567)

You can remove whiteSpacing in a string by doing this: 

```swift
string.components(separatedBy: .whitespaces).joined()
```

## Demo
<img src="https://user-images.githubusercontent.com/12765774/42638749-ba6dadda-85ee-11e8-8f50-995729422edd.gif" width="300"/>

# How To Test 📲 

1. Copy a card and paste it in notes or messages. 
2. Check that there's no spacing between the numbers

